### PR TITLE
Add full screen carousel to home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A Next.js / React challenge consisting on creating an Star Wars fansite with some content and features.
 
+## REVIEW PROJECT'S PROGRESS
+
+Although this is a solo effort I'm keeping the git regular flow by doing Pull Requests, so my progress can be more traced and documented.
+
+In order to **know more about technical decissions** feel free to [check any merged Pull request](https://github.com/ElDav1d/playing-with-swapi-and-next-js/pulls?q=is%3Apr+is%3Amerged).
+
 ## ACCEPTANCE CRITERIA
 
 Create an Star Wars fansite with the following content:

--- a/components/atoms/CarouselPic/CarouselPic.tsx
+++ b/components/atoms/CarouselPic/CarouselPic.tsx
@@ -1,0 +1,9 @@
+import Image from "next/image";
+
+const CarouselPic = ({ path, title, alt }) => {
+  return (
+    <Image src={path} alt={alt} title={title} layout="fill" objectFit="cover" />
+  );
+};
+
+export default CarouselPic;

--- a/components/organisms/CarouselContainer/CarouselContainer.css
+++ b/components/organisms/CarouselContainer/CarouselContainer.css
@@ -1,0 +1,25 @@
+.CarouselContailer_UlOverride {
+  height: 75vh;
+}
+
+@media (min-width: 768px) {
+  .CarouselContailer_UlOverride {
+    height: 70vh;
+  }
+}
+
+@media (min-width: 1024px) {
+  .CarouselContailer_UlOverride {
+    height: 85vh;
+  }
+}
+
+.react-multi-carousel-list {
+  margin-bottom: 3rem;
+}
+
+@media (min-width: 1024px) {
+  .react-multi-carousel-list {
+    margin-bottom: 5rem;
+  }
+}

--- a/components/organisms/CarouselContainer/CarouselContainer.tsx
+++ b/components/organisms/CarouselContainer/CarouselContainer.tsx
@@ -20,37 +20,32 @@ const responsive = {
 const CarouselContainer = () => {
   return (
     <Carousel
-      // autoPlay={true}
+      autoPlay={true}
       autoPlaySpeed={5000}
       infinite={true}
       responsive={responsive}
       transitionDuration={1000}
+      sliderClass={"CarouselContailer_UlOverride"}
     >
       <Image
         src="https://vignette.wikia.nocookie.net/starwars/images/2/20/LukeTLJ.jpg"
         alt=""
-        layout="responsive"
+        layout="fill"
         objectFit="cover"
-        width={100}
-        height={100}
       />
 
       <Image
         src="https://vignette.wikia.nocookie.net/starwars/images/4/48/Chewbacca_TLJ.png"
         alt=""
-        layout="responsive"
+        layout="fill"
         objectFit="cover"
-        width={100}
-        height={100}
       />
 
       <Image
         src="https://vignette.wikia.nocookie.net/starwars/images/e/e2/TFAHanSolo.png"
         alt=""
-        layout="responsive"
+        layout="fill"
         objectFit="cover"
-        width={100}
-        height={100}
       />
     </Carousel>
   );

--- a/components/organisms/CarouselContainer/CarouselContainer.tsx
+++ b/components/organisms/CarouselContainer/CarouselContainer.tsx
@@ -1,5 +1,6 @@
 import "react-multi-carousel/lib/styles.css";
 import Carousel from "react-multi-carousel";
+import Image from "next/image";
 
 const responsive = {
   desktop: {
@@ -19,25 +20,37 @@ const responsive = {
 const CarouselContainer = () => {
   return (
     <Carousel
-      autoPlay={true}
+      // autoPlay={true}
       autoPlaySpeed={5000}
       infinite={true}
       responsive={responsive}
       transitionDuration={1000}
     >
-      <img
+      <Image
         src="https://vignette.wikia.nocookie.net/starwars/images/2/20/LukeTLJ.jpg"
         alt=""
+        layout="responsive"
+        objectFit="cover"
+        width={100}
+        height={100}
       />
 
-      <img
+      <Image
         src="https://vignette.wikia.nocookie.net/starwars/images/4/48/Chewbacca_TLJ.png"
         alt=""
+        layout="responsive"
+        objectFit="cover"
+        width={100}
+        height={100}
       />
 
-      <img
+      <Image
         src="https://vignette.wikia.nocookie.net/starwars/images/e/e2/TFAHanSolo.png"
         alt=""
+        layout="responsive"
+        objectFit="cover"
+        width={100}
+        height={100}
       />
     </Carousel>
   );

--- a/components/organisms/CarouselContainer/CarouselContainer.tsx
+++ b/components/organisms/CarouselContainer/CarouselContainer.tsx
@@ -1,0 +1,46 @@
+import "react-multi-carousel/lib/styles.css";
+import Carousel from "react-multi-carousel";
+
+const responsive = {
+  desktop: {
+    breakpoint: { max: 3000, min: 1024 },
+    items: 1,
+  },
+  tablet: {
+    breakpoint: { max: 1024, min: 768 },
+    items: 1,
+  },
+  mobile: {
+    breakpoint: { max: 768, min: 0 },
+    items: 1,
+  },
+};
+
+const CarouselContainer = () => {
+  return (
+    <Carousel
+      autoPlay={true}
+      autoPlaySpeed={5000}
+      infinite={true}
+      responsive={responsive}
+      transitionDuration={1000}
+    >
+      <img
+        src="https://vignette.wikia.nocookie.net/starwars/images/2/20/LukeTLJ.jpg"
+        alt=""
+      />
+
+      <img
+        src="https://vignette.wikia.nocookie.net/starwars/images/4/48/Chewbacca_TLJ.png"
+        alt=""
+      />
+
+      <img
+        src="https://vignette.wikia.nocookie.net/starwars/images/e/e2/TFAHanSolo.png"
+        alt=""
+      />
+    </Carousel>
+  );
+};
+
+export default CarouselContainer;

--- a/components/organisms/CarouselContainer/CarouselContainer.tsx
+++ b/components/organisms/CarouselContainer/CarouselContainer.tsx
@@ -1,6 +1,6 @@
 import "react-multi-carousel/lib/styles.css";
+import CarouselPic from "../../atoms/CarouselPic/CarouselPic";
 import Carousel from "react-multi-carousel";
-import Image from "next/image";
 
 const responsive = {
   desktop: {
@@ -17,9 +17,7 @@ const responsive = {
   },
 };
 
-const CarouselContainer = ({ pics }) => {
-  console.log(pics);
-
+const CarouselContainer = ({ carouselPics }) => {
   return (
     <Carousel
       autoPlay={true}
@@ -29,26 +27,9 @@ const CarouselContainer = ({ pics }) => {
       transitionDuration={1000}
       sliderClass={"CarouselContailer_UlOverride"}
     >
-      <Image
-        src="https://vignette.wikia.nocookie.net/starwars/images/2/20/LukeTLJ.jpg"
-        alt=""
-        layout="fill"
-        objectFit="cover"
-      />
-
-      <Image
-        src="https://vignette.wikia.nocookie.net/starwars/images/4/48/Chewbacca_TLJ.png"
-        alt=""
-        layout="fill"
-        objectFit="cover"
-      />
-
-      <Image
-        src="https://vignette.wikia.nocookie.net/starwars/images/e/e2/TFAHanSolo.png"
-        alt=""
-        layout="fill"
-        objectFit="cover"
-      />
+      {carouselPics.map(({ path, title, alt }, index) => (
+        <CarouselPic path={path} title={title} alt={alt} key={index} />
+      ))}
     </Carousel>
   );
 };

--- a/components/organisms/CarouselContainer/CarouselContainer.tsx
+++ b/components/organisms/CarouselContainer/CarouselContainer.tsx
@@ -17,7 +17,9 @@ const responsive = {
   },
 };
 
-const CarouselContainer = () => {
+const CarouselContainer = ({ pics }) => {
+  console.log(pics);
+
   return (
     <Carousel
       autoPlay={true}

--- a/components/organisms/CharactersListContainer/CharactersListContainer.tsx
+++ b/components/organisms/CharactersListContainer/CharactersListContainer.tsx
@@ -1,6 +1,17 @@
+import styled from "styled-components";
 import { CharacterItems } from "../../../interfaces";
 import CharactersList from "../../molecules/CharactersList/CharactersList";
 import CharactersListPagination from "../../molecules/CharacterListPagination/CharacterListPagination";
+
+const MainHeading = styled.h1`
+  margin: 1rem;
+  @media (min-width: 768px) {
+    margin: 2.5rem 1rem;
+  }
+  @media (min-width: 1024px) {
+    margin: 3rem 1rem;
+  }
+`;
 
 type Props = {
   characters: CharacterItems;
@@ -13,13 +24,13 @@ const CharactersListContainer = ({ characters }: Props) => {
     <article>
       {characters.length ? (
         <section>
-          <h2>Lister Page</h2>
+          <MainHeading>Lister Page</MainHeading>
           <CharactersList characters={characters} />
         </section>
       ) : (
         <section data-testid="filter-fail-message-block">
-          <h2>{FILTER_FAIL_HEADING}</h2>
-          <h3>{FILTER_FAIL_SUBHEADING}</h3>
+          <MainHeading>{FILTER_FAIL_HEADING}</MainHeading>
+          <h2>{FILTER_FAIL_SUBHEADING}</h2>
         </section>
       )}
       <section>

--- a/components/organisms/CharactersListContainer/CharactersListContainer.tsx
+++ b/components/organisms/CharactersListContainer/CharactersListContainer.tsx
@@ -28,7 +28,7 @@ const CharactersListContainer = ({ characters }: Props) => {
           <CharactersList characters={characters} />
         </section>
       ) : (
-        <section data-testid="filter-fail-message-block">
+        <section>
           <MainHeading>{FILTER_FAIL_HEADING}</MainHeading>
           <h2>{FILTER_FAIL_SUBHEADING}</h2>
         </section>

--- a/interfaces.ts
+++ b/interfaces.ts
@@ -13,3 +13,11 @@ export type CharacterItem = {
 };
 
 export type CharacterItems = CharacterItem[];
+
+export type CarouselPics = CarouselPic[];
+
+export type CarouselPic = {
+  path: string;
+  title: string;
+  alt: string;
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
+  moduleNameMapper: {
+    "\\.(css|less|scss|sass)$": "identity-obj-proxy"
+  },
 };

--- a/mocks.js
+++ b/mocks.js
@@ -30,3 +30,21 @@ export const mockCharacterList = [
     index: 4,
   },
 ]
+
+export const mockHomeCarouselPics = [
+  {
+    path: "https://vignette.wikia.nocookie.net/starwars/images/2/20/LukeTLJ.jpg",
+    title: "Luke Skywalker",
+    alt: "An old version of Luke Skywalker"
+  },
+  {
+    path: "https://vignette.wikia.nocookie.net/starwars/images/e/e2/TFAHanSolo.png",
+    title: "Han Solo",
+    alt: "An old version of Han Solo"
+  },
+  {
+    path: "https://vignette.wikia.nocookie.net/starwars/images/4/48/Chewbacca_TLJ.png",
+    title: "Chewbacca",
+    alt: "A non so old version of Chewbacca"
+  },
+]

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  images: {
+    domains: ['vignette.wikia.nocookie.net'],
+  },
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "17.0.1",
     "react-combine-reducers": "^1.1.1",
     "react-dom": "17.0.1",
+    "react-multi-carousel": "^2.6.3",
     "react-paginate": "^7.1.0",
     "styled-components": "^5.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/react": "^17.0.2",
     "@types/styled-components": "^5.1.7",
     "babel-plugin-styled-components": "^1.12.0",
+    "identity-obj-proxy": "^3.0.0",
     "typescript": "^4.2.2"
   }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from "react";
 import GlobalStyle from "../styles/GlobalStyle";
 import { CharactersContextProvider } from "../context/Characters";
+import "../components/organisms/CarouselContainer/CarouselContainer.css";
 
 function MyApp({ Component, pageProps }) {
   return (

--- a/pages/character/[id].tsx
+++ b/pages/character/[id].tsx
@@ -2,8 +2,14 @@ import styled from "styled-components";
 import { GetStaticProps, GetStaticPaths } from "next";
 import Layout from "../../components/templates/Layout/Layout";
 
-const Title = styled.h1`
+const MainHeading = styled.h1`
   margin: 1rem;
+  @media (min-width: 768px) {
+    margin: 2.5rem 1rem;
+  }
+  @media (min-width: 1024px) {
+    margin: 3rem 1rem;
+  }
 `;
 
 type CharacterData = {
@@ -19,7 +25,7 @@ type PageParam = string;
 export default function CharacterPage({ character }: Props) {
   return (
     <Layout title={`${character.name}'s page`}>
-      <Title>{character.name}</Title>
+      <MainHeading>{character.name}</MainHeading>
     </Layout>
   );
 }

--- a/pages/characters-list/[page].tsx
+++ b/pages/characters-list/[page].tsx
@@ -1,14 +1,9 @@
-import styled from "styled-components";
 import { GetStaticProps, GetStaticPaths } from "next";
 
 import { CharacterItems } from "../../interfaces";
 import { useCharactersContext } from "../../context/Characters";
 import Layout from "../../components/templates/Layout/Layout";
 import CharactersListContainer from "../../components/organisms/CharactersListContainer/CharactersListContainer";
-
-const Title = styled.h1`
-  margin: 1rem;
-`;
 
 type Props = {
   charactersOnPage: CharacterItems;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import Layout from "../components/templates/Layout/Layout";
+import CarouselContainer from "../components/organisms/CarouselContainer/CarouselContainer";
 
 const Title = styled.h1`
   margin: 5rem 1rem;
@@ -9,6 +10,7 @@ export default function Home() {
   return (
     <Layout title="Star Wars Character Database Home Page">
       <Title>Home Page</Title>
+      <CarouselContainer />
     </Layout>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,7 +9,7 @@ type Props = {
   picsOnCarousel: CarouselPics;
 };
 
-const Title = styled.h1`
+const MainHeading = styled.h1`
   margin: 1rem;
   @media (min-width: 768px) {
     margin: 2.5rem 1rem;
@@ -19,10 +19,12 @@ const Title = styled.h1`
   }
 `;
 
+const HOME_PAGE_TITLE: string = "Star Wars Character Database Home Page";
+
 export default function Home({ picsOnCarousel }: Props) {
   return (
-    <Layout title="Star Wars Character Database Home Page">
-      <Title>Home Page</Title>
+    <Layout title={HOME_PAGE_TITLE}>
+      <MainHeading>{HOME_PAGE_TITLE}</MainHeading>
       <CarouselContainer carouselPics={picsOnCarousel} />
     </Layout>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,7 +23,7 @@ export default function Home({ picsOnCarousel }: Props) {
   return (
     <Layout title="Star Wars Character Database Home Page">
       <Title>Home Page</Title>
-      <CarouselContainer pics={picsOnCarousel} />
+      <CarouselContainer carouselPics={picsOnCarousel} />
     </Layout>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,13 @@
+import { mockHomeCarouselPics } from "../mocks";
+import { GetStaticProps } from "next";
+import { CarouselPics } from "../interfaces";
 import styled from "styled-components";
 import Layout from "../components/templates/Layout/Layout";
 import CarouselContainer from "../components/organisms/CarouselContainer/CarouselContainer";
+
+type Props = {
+  picsOnCarousel: CarouselPics;
+};
 
 const Title = styled.h1`
   margin: 1rem;
@@ -12,11 +19,21 @@ const Title = styled.h1`
   }
 `;
 
-export default function Home() {
+export default function Home({ picsOnCarousel }: Props) {
   return (
     <Layout title="Star Wars Character Database Home Page">
       <Title>Home Page</Title>
-      <CarouselContainer />
+      <CarouselContainer pics={picsOnCarousel} />
     </Layout>
   );
 }
+
+export const getStaticProps: GetStaticProps = async () => {
+  const picsOnCarousel = mockHomeCarouselPics;
+
+  return {
+    props: {
+      picsOnCarousel,
+    },
+  };
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,13 @@ import Layout from "../components/templates/Layout/Layout";
 import CarouselContainer from "../components/organisms/CarouselContainer/CarouselContainer";
 
 const Title = styled.h1`
-  margin: 5rem 1rem;
+  margin: 1rem;
+  @media (min-width: 768px) {
+    margin: 2.5rem 1rem;
+  }
+  @media (min-width: 1024px) {
+    margin: 3rem 1rem;
+  }
 `;
 
 export default function Home() {

--- a/tests/components/carouselPic.test.js
+++ b/tests/components/carouselPic.test.js
@@ -1,0 +1,23 @@
+import { render, screen } from '../test-utils';
+import { mockHomeCarouselPics } from '../../mocks';
+
+import CarouselPic from '../../components/atoms/CarouselPic/CarouselPic';
+
+const mockedPic = mockHomeCarouselPics[0];
+const anyTextmatcher = /.*?/i
+
+describe("CarouselPic renders an image with SEO/accesibility attributes: ", () => {
+  beforeEach(() => {
+    render(
+      <CarouselPic path={mockedPic.path} title={mockedPic.title} alt={mockedPic.alt} />
+    );
+  })
+
+  it("one is 'alt' attribute", () => {
+    expect(screen.getByAltText(anyTextmatcher)).toBeInTheDocument;
+  })
+
+  it("one is 'title' attribute", () => {
+    expect(screen.getByTitle(anyTextmatcher)).toBeInTheDocument;
+  })
+})

--- a/tests/pages/home.test.js
+++ b/tests/pages/home.test.js
@@ -1,4 +1,5 @@
 import { render, screen } from '../test-utils.js';
+import { mockHomeCarouselPics } from '../../mocks'
 
 import { CharactersContextProvider } from '../../context/Characters';
 import Home from '../../pages/index.tsx';
@@ -11,11 +12,20 @@ jest.mock('next/router', () => ({
   }
 }))
 
+jest.mock('next/head', () => {
+  return {
+    __esModule: true,
+    default: ({ children }) => {
+      return <>{children}</>;
+    },
+  };
+});
+
 describe('Home', () => {
   beforeEach(() => {
     render(
       <CharactersContextProvider>
-        <Home />
+        <Home picsOnCarousel={mockHomeCarouselPics} />
       </CharactersContextProvider>
     );
   })
@@ -35,5 +45,17 @@ describe('Home', () => {
     const searchInput = screen.queryByRole('textbox', { placeholder: /type something/i });
 
     expect(searchInput).not.toBeInTheDocument();
+  })
+
+  it("it first renders a heading with the page's title", () => {
+    const heading = screen.getByRole('heading', { name: document.title });
+
+    expect(heading).toBeInTheDocument();
+  })
+
+  it("renders the outer list of the images' carousel", () => {
+    const carouselList = screen.getByRole('list');
+
+    expect(carouselList).toHaveClass("react-multi-carousel-track");
   })
 })

--- a/tests/pages/listerPage.test.js
+++ b/tests/pages/listerPage.test.js
@@ -168,10 +168,23 @@ describe("characters' list displays", () => {
     userEvent.type(searchInput, 'condemor');
     act(() => jest.advanceTimersByTime(DEBOUNCE_TIME))
 
-    const filterFailMessage = await screen.findByTestId('filter-fail-message-block');
-
     expect(charactersList).not.toBeInTheDocument();
-    expect(filterFailMessage).toBeInTheDocument();
+  })
+
+  it("an error message when not matching search input", async () => {
+    const DEBOUNCE_TIME = 750
+    const HEADING_TEXT = /these are not the droids you're looking for/i;
+    const SUBHEADING_TEXT = /try searching for something else!/i
+    const searchInput = screen.getByRole('textbox', { placeholder: /type something/i });
+
+    userEvent.type(searchInput, 'condemor');
+    act(() => jest.advanceTimersByTime(DEBOUNCE_TIME))
+
+    const filterFailHeading = await screen.findByRole('heading', { name: HEADING_TEXT });
+    const filterFailSubheading = await screen.findByRole('heading', { name: SUBHEADING_TEXT });
+
+    expect(filterFailHeading).toBeInTheDocument();
+    expect(filterFailSubheading).toBeInTheDocument();
   })
 
   it("one item when specific search input match", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4205,6 +4205,11 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
+react-multi-carousel@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/react-multi-carousel/-/react-multi-carousel-2.6.3.tgz#9ec39110de17feb6075cb134d046ae2e02df6b98"
+  integrity sha512-fCe+I1BlhTUyNHm/fh3bWavDo8UzoolTd/zrKao/wvb/XFf9dvesfNOawx7ukAzptiHOQhGCWZiNao+J76Byfw==
+
 react-paginate@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/react-paginate/-/react-paginate-7.1.0.tgz#7dc244ad7ca2db59b6eb83472655de3c126be1bc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2360,6 +2360,11 @@ har-validator@~5.1.3:
     ajv "^6.12.3"
     har-schema "^2.0.0"
 
+harmony-reflect@^1.4.6:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
+  integrity sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -2504,6 +2509,13 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  integrity sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"


### PR DESCRIPTION
### According to ACCEPTANCE CRITERIA (README.md):

3.Homepage
   a. Content:
   I. Full screen carousel of images from Star Wars

## WHAT

* Home page has a carousel with 3 SW accesible character pics.

* Home page's title and h1 are consistent.

* Carousel and its pics are added in the tests' flow.

## HOW

* Carousel is built using [_react-multi-carousel_](https://www.npmjs.com/package/react-multi-carousel)

* Pic data is mocked with hardcoded URL'S of https://github.com/akabab/starwars-api, and added into the _getStaticProps_ pattern for the sake of consistence/scalability.

* A CSS override was needed to _stretch_ the carousel's parent container so Next.js Image component could be used 

## TRADEOFFS/TODOS

* The CSS override is placed at app level so it's rulesets will be loaded at the whole application. This is because Next.js is not allowing scoped stylesheets but modules, and that would conflict with the component vendor stylesheet because the randomly generated selector names.

* Tests are _a bit shallow_ as long as _react-multi-carousel_ is obfuscating the accesible roles under the hood. I only could check for the pressence ot the parent element, and the atributtes of an item/pic.

* Matching SWAPI data with starwars-api pics would be a challenging improvement that would allow to remove hardcoded stuff.
